### PR TITLE
Map icon jumping and color fixes

### DIFF
--- a/client/src/components/Benchmarking.js
+++ b/client/src/components/Benchmarking.js
@@ -79,7 +79,7 @@ export default function Benchmarking() {
     sizeScale: 6,
     getPosition: (d) => d.coordinates,
     getSize: (d) => 5,
-    getColor: (d) => [Math.sqrt(d.exits), 140, 0],
+    getColor: (d) => [0, 118, 129],
   });
 
   return (


### PR DESCRIPTION
Added anchorY to [ICON_MAPPING in Benchmarking.js ](https://github.com/rongxinyin/DF-Assessment-Tool/blob/d2becca19033901027e2088b75ba27926d01ca48/client/src/components/Benchmarking.js#L66) so that the markers don't move when you zoom in and out.

**Before**: 

https://github.com/user-attachments/assets/967da8c7-eb59-4f05-9acd-85c1978cba64

Markers don't stay in one place, with ones in San Diego appearing in Mexico and ones in Tulsa showing up in Texas.

**After**:

https://github.com/user-attachments/assets/564351de-e66d-4ec7-9552-35cb8044a6ff

Markers stay where they are no matter the zoom level.

